### PR TITLE
Add difficultWordsSet() function

### DIFF
--- a/main.js
+++ b/main.js
@@ -196,7 +196,10 @@ class Readability {
     }
     return word
   }
-  difficultWords (text, syllableThreshold = 2) {
+  difficultWords (text, syllableThreshold) {
+    return [...this.difficultWordsSet(text, syllableThreshold)].length
+  }
+  difficultWordsSet (text, syllableThreshold = 2) {
     const textList = text.match(/[\w=‘’]+/g)
     const diffWordsSet = new Set()
     if (textList === null)
@@ -209,7 +212,7 @@ class Readability {
         diffWordsSet.add(word)
       }
     }
-    return [...diffWordsSet].length
+    return diffWordsSet
   }
   daleChallReadabilityScore (text) {
     const wordCount = this.lexiconCount(text)

--- a/main.test.js
+++ b/main.test.js
@@ -28,6 +28,7 @@ function test () {
   console.log('automatedReadabilityIndex: \n', ts.automatedReadabilityIndex(text))
   console.log('linsearWriteFormula: \n', ts.linsearWriteFormula(text))
   console.log('difficultWords: \n', ts.difficultWords(text))
+  console.log('difficultWordsSet: \n', ts.difficultWordsSet(text))
   console.log('daleChallReadabilityScore: \n', ts.daleChallReadabilityScore(text))
   console.log('daleChallReadabilityScore grade: \n', ts.daleChallToGrade(ts.daleChallReadabilityScore(text)))
   console.log('gunningFog: \n', ts.gunningFog(text))


### PR DESCRIPTION
I added difficultWordsSet() function.
This function returns the difficult words as `Set` object.

```bash
$ node main.test.js
difficultWords: 
 5
difficultWordsSet: 
 Set(5) {
  'spontaneous',
  'remission',
  'psychedelic',
  'experience',
  'spatial'
}

```

Use cases
- Discover difficult words in Privacy Policy and Disclaimer documents. 
  - It helps the legal writer to make readable documents.
- Develop web application in English, but use readable words in order to make usability for other region users. 

https://www.npmjs.com/package/textlint-rule-no-difficult-words uses text-readability package!
Thank you. 
