### PR TITLE
Fix Math.copySign function

### DIFF
--- a/main.js
+++ b/main.js
@@ -172,8 +172,7 @@ class Readability {
     text = textList.join(' ')
     let number = (easyWord * 1 + difficultWord * 3) / this.sentenceCount(text)
     let returnVal = number <= 20 ? (number - 2) / 2 : number / 2
-    returnVal = Math.legacyRound(returnVal, 1)
-    return !isNaN(returnVal) ? returnVal : 0.0
+    return Math.legacyRound(returnVal, 1)
   }
   presentTense(word) {
     // good enough for most long words -- we only care about "difficult" words
@@ -236,9 +235,9 @@ class Readability {
   }
   gunningFog (text) {
     const perDiffWords = (this.difficultWords(text, 3) / this.lexiconCount(text) * 100)
+    if (isNaN(perDiffWords)) return 0.0
     const grade = 0.4 * (this.averageSentenceLength(text) + perDiffWords)
-    const returnVal = Math.legacyRound(grade, 2)
-    return !isNaN(returnVal) ? returnVal : 0.0
+    return Math.legacyRound(grade, 2)
   }
   lix (text) {
     const words = Readability.split(text)

--- a/main.js
+++ b/main.js
@@ -6,6 +6,7 @@ const easyWordSet = new Set(easyWords)
 
 // extends Math object
 Math.copySign = (x, y) => {
+  if (y === 0) return 0;
   return x * (y / Math.abs(y))
 }
 Math.legacyRound = (number, points = 0) => {


### PR DESCRIPTION
When `Math.legacyRound` is used in a function and the text is empty, `Math.copySign` attempts to divide by `0` and returns `NaN` as a result. In most of the functions, this is handled by checking for `NaN` and returning `0.0` instead. However, in the `colemanLiauIndex` function, this was not the case and the function would return `NaN`. This change causes `Math.copySign` to immediately return `0` if the divisor is `0`. Additionally, this removes the `isNaN` checks that were implemented because of this error.